### PR TITLE
Remove `buffer-from` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "homepage": "https://github.com/TooTallNate/node-data-uri-to-buffer",
   "devDependencies": {
-    "@types/buffer-from": "^1.1.0",
     "@types/es6-promisify": "^5.0.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.5.3",
@@ -52,8 +51,5 @@
     "eslint-plugin-react": "7.12.4",
     "mocha": "^6.2.0",
     "typescript": "^3.5.3"
-  },
-  "dependencies": {
-    "buffer-from": "^1.1.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import bufferFrom from 'buffer-from';
-
 /**
  * Returns a `Buffer` instance from the given data URI `uri`.
  *
@@ -50,7 +48,7 @@ function dataUriToBuffer(uri: string): dataUriToBuffer.MimeBuffer {
 	// get the encoded data portion and decode URI-encoded chars
 	const encoding = base64 ? 'base64' : 'ascii';
 	const data = unescape(uri.substring(firstComma + 1));
-	const buffer = bufferFrom(data, encoding) as dataUriToBuffer.MimeBuffer;
+	const buffer = Buffer.from(data, encoding) as dataUriToBuffer.MimeBuffer;
 
 	// set `.type` and `.typeFull` properties to MIME type
 	buffer.type = type;


### PR DESCRIPTION
`Buffer.from()` was added in Node.js v5.10.0, which is old
enough for the versions this module should support.

Closes #14.