### PR TITLE
fix: parse meta with unnecessary semicolons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export function dataUriToBuffer(uri: string): MimeBuffer {
 	for (let i = 1; i < meta.length; i++) {
 		if (meta[i] === 'base64') {
 			base64 = true;
-		} else {
+		} else if(meta[i]) {
 			typeFull += `;${  meta[i]}`;
 			if (meta[i].indexOf('charset=') === 0) {
 				charset = meta[i].substring(8);

--- a/test/data-uri-to-buffer.test.ts
+++ b/test/data-uri-to-buffer.test.ts
@@ -173,4 +173,13 @@ describe('data-uri-to-buffer', function() {
 		assert.equal('UTF-8', buf.charset);
 		assert.equal('abc', buf.toString());
 	});
+
+	it('should parse meta with unnecessary semicolons', function() {
+		var uri = 'data:text/plain;;charset=UTF-8;;;base64;;;;,YWJj';
+		var buf = dataUriToBuffer(uri);
+		assert.equal('text/plain', buf.type);
+		assert.equal('text/plain;charset=UTF-8', buf.typeFull);
+		assert.equal('UTF-8', buf.charset);
+		assert.equal('abc', buf.toString());
+	});
 });


### PR DESCRIPTION
Hello again,

this fixes #17 by simply ignoring empty meta entries.